### PR TITLE
Misc wgpu 22 cleanup.

### DIFF
--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -241,7 +241,7 @@ impl Preprocessor {
         let mut final_string = String::new();
         let mut offset = 0;
 
-        #[cfg(debug)]
+        #[cfg(debug_assertions)]
         let len = shader_str.len();
 
         // this code broadly stolen from bevy_render::ShaderProcessor
@@ -371,12 +371,12 @@ impl Preprocessor {
 
         scope.finish(offset)?;
 
-        #[cfg(debug)]
+        #[cfg(debug_assertions)]
         if validate_len {
             let revised_len = final_string.len();
-            assert_eq!(len, revised_len);
+            debug_assert_eq!(len, revised_len);
         }
-        #[cfg(not(debug))]
+        #[cfg(not(debug_assertions))]
         let _ = validate_len;
 
         Ok(PreprocessOutput {


### PR DESCRIPTION
We can remove the `subgroup_stages` detection as it's now properly handled with just naga's `Capabilities`.

Change `#[cfg(debug)]` to `#[cfg(debug_assertions)]` because `#[cfg(debug)]` isn't actually a thing, and rust 1.80 is complaining about it.